### PR TITLE
fix: override loader & router to not redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.0.0",
+    "gatsby": "^2.11.1",
     "@reach/router": "^1.2.1"
   },
   "devDependencies": {

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,26 +1,32 @@
 
 // We override loadPage & loadPagesync to fix canonical redirects
 exports.onClientEntry = () => {
-  if (!window.___loader) {
+  const loader = window.___loader;
+
+  // if there is no loader we shouldn't do anything (gatsby doesn't expose loader on develop)
+  if (!loader) {
     return;
   }
 
-  if (window.pagePath !== location.pathname && window.pagePath !== location.pathname + '/') {
-    const originalLoadPageSync = window.___loader.loadPageSync;
-    const originalLoadPage = window.___loader.loadPage;
+  const pagePath = window.pagePath;
+  const location = window.location;
 
-    window.___loader.loadPageSync = path => {
+  if (pagePath !== location.pathname && pagePath !== location.pathname + '/') {
+    const originalLoadPageSync = loader.loadPageSync;
+    const originalLoadPage = loader.loadPage;
+
+    loader.loadPageSync = path => {
       // if the path is the same as our current page we know it's not a prefetch
-      if (path === window.location.pathname) {
-        return originalLoadPageSync(window.pagePath);
+      if (path === location.pathname) {
+        return originalLoadPageSync(pagePath);
       }
 
       return originalLoadPageSync(path);
     }
-    window.___loader.loadPage = path => {
+    loader.loadPage = path => {
       // if the path is the same as our current page we know it's not a prefetch
-      if (path === window.location.pathname) {
-        return originalLoadPage(window.pagePath);
+      if (path === location.pathname) {
+        return originalLoadPage(pagePath);
       }
 
       return originalLoadPage(path);

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,0 +1,25 @@
+
+// We override loadPage & loadPagesync to fix canonical redirects
+exports.onClientEntry = () => {
+  if (window.pagePath !== location.pathname && window.pagePath !== location.pathname + '/') {
+    const originalLoadPageSync = window.___loader.loadPageSync;
+    const originalLoadPage = window.___loader.loadPage;
+
+    window.___loader.loadPageSync = path => {
+      // if the path is the same as our current page we know it's not a prefetch
+      if (path === window.location.pathname) {
+        return originalLoadPageSync(window.pagePath);
+      }
+
+      return originalLoadPageSync(path);
+    }
+    window.___loader.loadPage = path => {
+      // if the path is the same as our current page we know it's not a prefetch
+      if (path === window.location.pathname) {
+        return originalLoadPage(window.pagePath);
+      }
+
+      return originalLoadPage(path);
+    }
+  }
+}

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,6 +1,10 @@
 
 // We override loadPage & loadPagesync to fix canonical redirects
 exports.onClientEntry = () => {
+  if (!window.___loader) {
+    return;
+  }
+
   if (window.pagePath !== location.pathname && window.pagePath !== location.pathname + '/') {
     const originalLoadPageSync = window.___loader.loadPageSync;
     const originalLoadPage = window.___loader.loadPage;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,9 @@
 export * from "@reach/router-original";
 
-export const navigate = url => {
-  window.location = url;
+export const navigate = (url, options) => {
+  // when we do not replace the current url or the replacement is just adding a slash we navigate
+  // this fixes canonical redirects
+  if (!options.replace || window.location.href + '/' === url) {
+    window.location = url;
+  }
 };


### PR DESCRIPTION
There seems to be an issue when url and path aren't the same. Gatsby tries to redirect to that url which will fail.

This PR fixes https://github.com/gatsbyjs/gatsby/issues/4337

demo:
https://static-asset-prefix--zen-wright-33c2d8.netlify.com/