### PR TITLE
fix: use matchPath to trick reach router to match router

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - attach_workspace:
           at: ./
       # Build plugin
-      - run: yarn build
+      - run: yarn lint
 
   build:
     executor: node

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
     }
   },
   rules: {
-    indent: ['error', 2],
+    'indent': ['error', 2, { 'SwitchCase': 1 }],
     'linebreak-style': ['error', 'unix'],
   },
   overrides: [

--- a/e2e-tests/asset-prefix/cypress/integration/navigation.js
+++ b/e2e-tests/asset-prefix/cypress/integration/navigation.js
@@ -28,4 +28,11 @@ describe('Navigation', function() {
 
     cy.get('[data-page]').should(`have.attr`, `data-page`, '1');
   });
+
+  it('A random rewritten url works in gatsby', () => {
+    cy.visit('http://localhost:3000/random-page');
+    cy.get('[data-page]').should(`have.attr`, `data-page`, 'random');
+
+    cy.get('#mytext').contains('hydrated');
+  });
 });

--- a/e2e-tests/asset-prefix/server.js
+++ b/e2e-tests/asset-prefix/server.js
@@ -16,6 +16,11 @@ app
       req.path = '/external' + req.url;
     }
 
+    if (req.url === '/random-page') {
+      req.url = '/external/page-different-url';
+      req.path = '/external/page-different-url';
+    }
+
     next();
   })
   .use('/external', assets)
@@ -29,6 +34,7 @@ app
       <li style="margin-bottom: 0px;"><a href="/page-2">Go back to page 2</a></li>
       <li style="margin-bottom: 0px;"><a href="/page-3">Go back to page 3</a></li>
       <li style="margin-bottom: 0px;"><a href="/page-4">Go back to page 4</a></li>
+      <li style="margin-bottom: 0px;"><a href="/random-page">Go back to random-page</a></li>
     </ul>
     `);
   })
@@ -42,6 +48,7 @@ app
       <li style="margin-bottom: 0px;"><a href="/">Go back to the homepage</a></li>
       <li style="margin-bottom: 0px;"><a href="/page-3">Go back to page 3</a></li>
       <li style="margin-bottom: 0px;"><a href="/page-4">Go back to page 4</a></li>
+      <li style="margin-bottom: 0px;"><a href="/random-page">Go back to random-page</a></li>
     </ul>
     `);
   })

--- a/e2e-tests/asset-prefix/src/components/pageList.js
+++ b/e2e-tests/asset-prefix/src/components/pageList.js
@@ -9,11 +9,22 @@ export default function PageList({ hidePage }) {
       continue;
     }
 
-    pages.push(
-      <Link to={i === 1 ? '/' : `/page-${i}`}>
-        Go back to {i === 1 ? 'the homepage' : `page ${i}`}
-      </Link>
-    );
+    let page;
+    switch (i) {
+      case 1: {
+        page = <Link to="/">Go back to the homepage</Link>;
+        break;
+      }
+      case 5: {
+        page = <Link to="/random-page">Random page</Link>;
+        break;
+      }
+      default: {
+        page = <Link to={`/page-${i}`}>Go back to {`page ${i}`}</Link>;
+      }
+    }
+
+    pages.push(page);
   }
 
   return (

--- a/e2e-tests/asset-prefix/src/pages/page-different-url.js
+++ b/e2e-tests/asset-prefix/src/pages/page-different-url.js
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+import PageList from '../components/pageList';
+
+const ClientOnly = () => {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    setText('hydrated');
+  }, []);
+
+  return <span id="mytext">{text}</span>;
+};
+
+const RandomPage = () => (
+  <Layout>
+    <SEO title="Page random url" />
+    <h1 data-page="random">Hi from the random page</h1>
+    <p>Welcome to a random page</p>
+    <ClientOnly />
+    <PageList hidePage={5} />
+  </Layout>
+);
+
+export default RandomPage;

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -3,8 +3,8 @@
 exports.onClientEntry = () => {
   const loader = window.___loader;
 
-  // if there is no loader we shouldn't do anything (gatsby doesn't expose loader on develop)
-  if (!loader) {
+  // if development or no loader exists we shouldn't do anything
+  if (process.env.NODE_ENV === 'development' || !loader) {
     return;
   }
 


### PR DESCRIPTION
Fixes page going blank mentionend in: https://github.com/wardpeet/gatsby-plugin-static-site/issues/5

For the plugin to properly work needs the https://github.com/wardpeet/gatsby-plugin-static-site/pull/9 merged as well

By setting a wildcard in the matchpath the routing at component level is disabled, as it will accept any path when setting the path in the gatsby core production app

![image](https://user-images.githubusercontent.com/40391767/65675992-6a2ec900-e04f-11e9-9002-3b6a526d818e.png)

Also a check for pagePath has been added to fix the exception happening on gatsby develop