### PR TITLE
fix: disable loader override in develop

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -3,8 +3,8 @@
 exports.onClientEntry = () => {
   const loader = window.___loader;
 
-  // if there is no loader we shouldn't do anything (gatsby doesn't expose loader on develop)
-  if (!loader) {
+  // if development or no loader exists we shouldn't do anything
+  if (process.env.NODE_ENV === 'development' || !loader) {
     return;
   }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,6 +1,6 @@
 const GatsbyStaticSitePlugin = require('./GatsbyStaticSitePlugin');
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ actions, stage }) => {
   // don't add plugin 
   if (stage !== 'build-javascript') {
     return;

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -2,7 +2,7 @@ const GatsbyStaticSitePlugin = require('./GatsbyStaticSitePlugin');
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   // don't add plugin 
-  if (stage !== 'build-html') {
+  if (stage !== 'build-javascript') {
     return;
   }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,6 +1,11 @@
 const GatsbyStaticSitePlugin = require('./GatsbyStaticSitePlugin');
 
 exports.onCreateWebpackConfig = ({ actions }) => {
+  // don't add plugin 
+  if (stage !== 'build-html') {
+    return;
+  }
+
   // add webpack plugin to gatsby's webpack config
   actions.setWebpackConfig({
     plugins: [new GatsbyStaticSitePlugin()],


### PR DESCRIPTION
Add a more robust check for development mode in Gatsby. As an extra addition disable the navigation override in gatsby-develop as this would slow down development.

@xavivars would disable navigation override in development break anything for your setup?

Fixes #10