### PR TITLE
fix: browser-support using function instead of arrow fn

### DIFF
--- a/src/GatsbyStaticSitePlugin.js
+++ b/src/GatsbyStaticSitePlugin.js
@@ -25,7 +25,7 @@ module.exports = class GatsbyStaticSitePlugin {
                   // Add our own navigation function to gatsby
                   parser.state.current.addDependency(
                     new ConstDependency(
-                      `const ${name} = (url, options) => {
+                      `const ${name} = function (url, options) {
                   // when we do not replace the current url or the replacement is just adding a slash we navigate
                   // this fixes canonical redirects
                   if (!options.replace || window.location.href + '/' === url) {

--- a/src/GatsbyStaticSitePlugin.js
+++ b/src/GatsbyStaticSitePlugin.js
@@ -25,7 +25,7 @@ module.exports = class GatsbyStaticSitePlugin {
                   // Add our own navigation function to gatsby
                   parser.state.current.addDependency(
                     new ConstDependency(
-                      `const ${name} = function (url, options) {
+                      `function ${name}(url, options) {
                   // when we do not replace the current url or the replacement is just adding a slash we navigate
                   // this fixes canonical redirects
                   if (!options.replace || window.location.href + '/' === url) {


### PR DESCRIPTION
Update the literal expression to return a normal function, instead of an array function, to avoid and error on IE11.