### PR TITLE
fixed breaking change for Gatsby v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^4.0.0"
+    "gatsby": "^3.0.0 || ^4.0.0"
   },
   "files": [
     "gatsby-browser.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wardpeet/gatsby-plugin-static-site",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A plugin that disables client side routing for gatsby",
   "main": "index.js",
   "author": "Ward Peeters <ward@coding-tech.com>",
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^3.0.0"
+    "gatsby": "^4.0.0"
   },
   "files": [
     "gatsby-browser.js",

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -21,11 +21,14 @@ exports.onClientEntry = () => {
 
     loader.loadPageSync = path => {
       let pageResources;
-      // if the path is the same as our current page we know it's not a prefetch
-      if (path === location.pathname) {
+      // With Gatsby V4, path has been appended with window.location.search when invoking loadPageSync
+      const pathWithoutQueryParams = path.replace(location.search, '');
+
+      // if the pathWithoutQueryParams is the same as our current page we know it's not a prefetch
+      if (pathWithoutQueryParams === location.pathname) {
         pageResources = originalLoadPageSync(pagePath);
       } else {
-        pageResources = originalLoadPageSync(path);
+        pageResources = originalLoadPageSync(pathWithoutQueryParams);
       }
 
       if (pageResources.page) {
@@ -37,11 +40,14 @@ exports.onClientEntry = () => {
 
     loader.loadPage = path => {
       let pageResources;
-      // if the path is the same as our current page we know it's not a prefetch
-      if (path === location.pathname) {
+      // With Gatsby V4, path has been appended with window.location.search when invoking loadPage
+      const pathWithoutQueryParams = path.replace(location.search, '');
+
+      // if the pathWithoutQueryParams is the same as our current page we know it's not a prefetch
+      if (pathWithoutQueryParams === location.pathname) {
         pageResources = originalLoadPage(pagePath);
       } else {
-        pageResources = originalLoadPage(path);
+        pageResources = originalLoadPage(pathWithoutQueryParams);
       }
 
       if (pageResources.page) {


### PR DESCRIPTION
This PR bumps up Gatsby version compatibility for the plugin. Also, fixes the breaking change where `loadPageSync ` and `loadPage` are now being passed query params i.e. `window.location.search` appended to the `window.pathname`. This is the [line](https://github.com/gatsbyjs/gatsby/blob/09a911e68598d544e74a68423302e8f8b6a37407/packages/gatsby/cache-dir/production-app.js#L174) which does that. I have verified this fix for our app and it seems to be working.

Issues that can be closed: 

- [Issue#65](https://github.com/wardpeet/gatsby-plugin-static-site/issues/65)
- [Issue#64](https://github.com/wardpeet/gatsby-plugin-static-site/issues/64)

FYI, @wardpeet . Thanks