### PR TITLE
chore: add support for Gatsby v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wardpeet/gatsby-plugin-static-site",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.1",
   "description": "A plugin that disables client side routing for gatsby",
   "main": "index.js",
   "author": "Ward Peeters <ward@coding-tech.com>",
@@ -17,7 +17,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^3.0.0"
+    "gatsby": "^3.0.0 || ^4.0.0"
   },
   "files": [
     "gatsby-browser.js",

--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -11,6 +11,15 @@ exports.onClientEntry = () => {
   const pagePath = window.pagePath;
   const location = window.location;
 
+  const parsePathComponents = pathAndQuery => {
+    const queryIndex = pathAndQuery.indexOf('?');
+    const path =
+      queryIndex > -1 ? pathAndQuery.substr(0, queryIndex) : pathAndQuery;
+    const query = queryIndex > -1 ? pathAndQuery.substr(queryIndex) : '';
+
+    return { path, query };
+  };
+
   if (
     pagePath &&
     pagePath !== location.pathname &&
@@ -20,10 +29,16 @@ exports.onClientEntry = () => {
     const originalLoadPage = loader.loadPage;
 
     loader.loadPageSync = path => {
+      // with Gatsby v4, 'path' can now be a path component, or path component + query
+      const {
+        path: pathComponent,
+        query: queryComponent,
+      } = parsePathComponents(path);
+
       let pageResources;
       // if the path is the same as our current page we know it's not a prefetch
-      if (path === location.pathname) {
-        pageResources = originalLoadPageSync(pagePath);
+      if (pathComponent === location.pathname) {
+        pageResources = originalLoadPageSync(pagePath + queryComponent);
       } else {
         pageResources = originalLoadPageSync(path);
       }
@@ -36,10 +51,16 @@ exports.onClientEntry = () => {
     };
 
     loader.loadPage = path => {
+      // with Gatsby v4, 'path' can now be a path component, or path component + query
+      const {
+        path: pathComponent,
+        query: queryComponent,
+      } = parsePathComponents(path);
+
       let pageResources;
       // if the path is the same as our current page we know it's not a prefetch
-      if (path === location.pathname) {
-        pageResources = originalLoadPage(pagePath);
+      if (pathComponent === location.pathname) {
+        pageResources = originalLoadPage(pagePath + queryComponent);
       } else {
         pageResources = originalLoadPage(path);
       }


### PR DESCRIPTION
Apologies for duplicating the majority of functionality of this PR (https://github.com/wardpeet/gatsby-plugin-static-site/pull/66); I only realized after the fact that somebody else had already made an effort to address this.

I'm still opening a PR with this particular implementation because I think there is a key distinction between the two PRs that merits review: 

* I believe the query parameter passed in the `path` parameter to the `loader` should be preserved in the `originalLoadPageSync` and `originalLoadPage` functions (based on the behavior seen here: https://github.com/gatsbyjs/gatsby/pull/33209/files#diff-177ac96ca321818b0022cdaa9fda344808eed92150a112f28ff205cda29b8049R30)

I think that this supports the spirit of the change introduced in that PR (https://github.com/gatsbyjs/gatsby/pull/33209).